### PR TITLE
GH-99 Auto-assign forum tags & include title in thread's first message.

### DIFF
--- a/src/main/java/com/eternalcode/discordapp/DiscordApp.java
+++ b/src/main/java/com/eternalcode/discordapp/DiscordApp.java
@@ -129,7 +129,7 @@ public class DiscordApp {
                         new SayCommand(),
 
                         // GitHub review
-                        new GitHubReviewCommand(gitHubReviewService),
+                        new GitHubReviewCommand(gitHubReviewService, config),
 
                         // Level/Experience
                         new LevelCommand(levelService),

--- a/src/main/java/com/eternalcode/discordapp/config/AppConfig.java
+++ b/src/main/java/com/eternalcode/discordapp/config/AppConfig.java
@@ -98,6 +98,14 @@ public class AppConfig implements CdnConfig {
     public static class ReviewSystem {
         public long reviewForumId = 1090383282744590396L;
 
+        @Description({
+            "# Currently, as of writing this comment (17.08.2023 ^^), the only way to obtain a list of forum's ID ",
+            "# tags is by using the appropriate JDA method (ForumTag#getAvailableTags). ",
+            "# For simplicity, I decided to create a simple /review get-forum-tags-id command, which will return a list of tags. ",
+        })
+        public long mergedTagId = 1141531024795373578L;
+        public long inReviewForumTagId = 1141531024795373578L;
+
 
         public List<GitHubReviewUser> reviewers = new ArrayList<>(Collections.singletonList(
                 new GitHubReviewUser(852920601969950760L, "vluckyyy")

--- a/src/main/java/com/eternalcode/discordapp/config/ConfigManager.java
+++ b/src/main/java/com/eternalcode/discordapp/config/ConfigManager.java
@@ -14,6 +14,7 @@ public class ConfigManager {
             .createYamlLike()
             .getSettings()
             .withComposer(Instant.class, new InstantComposer())
+            .withMemberResolver(Visibility.PRIVATE)
             .build();
 
     private final File folder;

--- a/src/main/java/com/eternalcode/discordapp/review/GitHubReviewService.java
+++ b/src/main/java/com/eternalcode/discordapp/review/GitHubReviewService.java
@@ -46,7 +46,8 @@ public class GitHubReviewService {
             this.mentionReviewers(jda, pullRequest, messageId);
 
             return "Review created";
-        } catch (IOException exception) {
+        }
+        catch (IOException exception) {
             exception.printStackTrace();
             return "Something went wrong";
         }
@@ -103,8 +104,8 @@ public class GitHubReviewService {
             user.openPrivateChannel().queue(privateChannel -> {
                 try {
                     privateChannel.sendMessage(String.format("You have been assigned as a reviewer for this pull request: %s", pullRequest.toUrl())).queue();
-                } catch (Exception ignored) {
-
+                }
+                catch (Exception ignored) {
                 }
             });
 
@@ -186,7 +187,8 @@ public class GitHubReviewService {
                     }
                 }
             }
-        } catch (IOException exception) {
+        }
+        catch (IOException exception) {
             exception.printStackTrace();
         }
     }

--- a/src/main/java/com/eternalcode/discordapp/review/GitHubReviewTask.java
+++ b/src/main/java/com/eternalcode/discordapp/review/GitHubReviewTask.java
@@ -16,7 +16,7 @@ public class GitHubReviewTask extends TimerTask {
 
     @Override
     public void run() {
-        this.gitHubReviewService.deleteMergedPullRequests(this.jda);
+        this.gitHubReviewService.archiveMergedPullRequest(this.jda);
         this.gitHubReviewService.mentionReviewersOnAllReviewChannels(this.jda);
     }
 }

--- a/src/main/java/com/eternalcode/discordapp/review/command/GitHubReviewCommand.java
+++ b/src/main/java/com/eternalcode/discordapp/review/command/GitHubReviewCommand.java
@@ -2,7 +2,11 @@ package com.eternalcode.discordapp.review.command;
 
 import com.eternalcode.discordapp.config.AppConfig;
 import com.eternalcode.discordapp.review.GitHubReviewService;
-import com.eternalcode.discordapp.review.command.child.*;
+import com.eternalcode.discordapp.review.command.child.AddChild;
+import com.eternalcode.discordapp.review.command.child.ForumTagsIdChild;
+import com.eternalcode.discordapp.review.command.child.ListChild;
+import com.eternalcode.discordapp.review.command.child.RemoveChild;
+import com.eternalcode.discordapp.review.command.child.RequestChild;
 import com.jagrosh.jdautilities.command.SlashCommand;
 import com.jagrosh.jdautilities.command.SlashCommandEvent;
 import net.dv8tion.jda.api.Permission;

--- a/src/main/java/com/eternalcode/discordapp/review/command/GitHubReviewCommand.java
+++ b/src/main/java/com/eternalcode/discordapp/review/command/GitHubReviewCommand.java
@@ -1,17 +1,15 @@
 package com.eternalcode.discordapp.review.command;
 
+import com.eternalcode.discordapp.config.AppConfig;
 import com.eternalcode.discordapp.review.GitHubReviewService;
-import com.eternalcode.discordapp.review.command.child.AddChild;
-import com.eternalcode.discordapp.review.command.child.ListChild;
-import com.eternalcode.discordapp.review.command.child.RemoveChild;
-import com.eternalcode.discordapp.review.command.child.RequestChild;
+import com.eternalcode.discordapp.review.command.child.*;
 import com.jagrosh.jdautilities.command.SlashCommand;
 import com.jagrosh.jdautilities.command.SlashCommandEvent;
 import net.dv8tion.jda.api.Permission;
 
 public class GitHubReviewCommand extends SlashCommand {
 
-    public GitHubReviewCommand(GitHubReviewService gitHubReviewService) {
+    public GitHubReviewCommand(GitHubReviewService gitHubReviewService, AppConfig appConfig) {
         this.name = "review";
         this.help = "Review a GitHub pull request";
         this.userPermissions = new Permission[]{ Permission.MESSAGE_MANAGE };
@@ -20,7 +18,8 @@ public class GitHubReviewCommand extends SlashCommand {
                 new AddChild(gitHubReviewService),
                 new ListChild(gitHubReviewService),
                 new RemoveChild(gitHubReviewService),
-                new RequestChild(gitHubReviewService)
+                new RequestChild(gitHubReviewService),
+                new ForumTagsIdChild(appConfig),
         };
     }
 

--- a/src/main/java/com/eternalcode/discordapp/review/command/child/ForumTagsIdChild.java
+++ b/src/main/java/com/eternalcode/discordapp/review/command/child/ForumTagsIdChild.java
@@ -1,0 +1,34 @@
+package com.eternalcode.discordapp.review.command.child;
+
+import com.eternalcode.discordapp.config.AppConfig;
+import com.eternalcode.discordapp.review.GitHubReviewService;
+import com.eternalcode.discordapp.review.GitHubReviewUser;
+import com.jagrosh.jdautilities.command.SlashCommand;
+import com.jagrosh.jdautilities.command.SlashCommandEvent;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.channel.forums.ForumTag;
+
+import java.util.List;
+
+public class ForumTagsIdChild extends SlashCommand {
+
+    private final AppConfig appConfig;
+
+    public ForumTagsIdChild(AppConfig appConfig) {
+        this.name = "get-forum-tags-id";
+        this.help = "Get Review Forum Tags Id";
+
+        this.userPermissions = new Permission[]{ Permission.ADMINISTRATOR };
+
+        this.appConfig = appConfig;
+    }
+
+    @Override
+    public void execute(SlashCommandEvent event) {
+        long reviewForumId = this.appConfig.reviewSystem.reviewForumId;
+
+        List<ForumTag> forumTags = event.getJDA().getForumChannelById(reviewForumId).getAvailableTags();
+
+        event.reply("Forum Tags Id: " + forumTags).setEphemeral(true).queue();
+    }
+}


### PR DESCRIPTION
🛠️ Pomyślałem, że warto wprowadzić kosmetyczne usprawnienia w systemie review. Ten pull request rozwiązuje jedno z issue **(#79)**, chociaż nie implementuje dokładnie tego, co było zawarte w issue, to spełnia taką samą funkcję. Zamiast wyświetlać tytuł pull requesta jako tytuł wątku, teraz tytuł jest umieszczany w pierwszej wiadomości. Poniżej znajduje się zrzut ekranu prezentujący to rozwiązanie.

![image](https://github.com/EternalCodeTeam/DiscordOfficer/assets/65517973/97ef94b0-398f-40c6-8a15-8dfab4ec35c5)

Dodatkowo, ten PR wprowadza kosmetyczną zmianę. Po złożeniu prośby o review na serwerze Discord za pomocą komendy `/review request`, post automatycznie otrzymuje tag **"Waiting for Review"**. Gdy pull request zostanie złączony, automatycznie zostanie oznaczony tagiem **"Merged"**. Przykład tego nowego wyglądu można zobaczyć na zrzucie ekranu poniżej.

![image](https://github.com/EternalCodeTeam/DiscordOfficer/assets/65517973/c724ae18-b157-4a76-a31c-14278c68d38f)

Tagi są teraz przypisywane do prośby o review na podstawie identyfikatora tagu. Niestety, zgodnie z tym, co opisałem w klasie `AppConfig linia: 100-108`, obecnie **(17.08.2023 ^^)** nie jesteśmy w stanie uzyskać identyfikatora tagu bezpośrednio z aplikacji Discord. Aby to zrobić, trzeba ręcznie wywołać metodę z JDA **([ForumChannel#getAvailableTags](https://javadoc.io/doc/net.dv8tion/JDA/latest/net/dv8tion/jda/api/entities/channel/concrete/ForumChannel.html#getAvailableTags()))**. Dla ułatwienia tego procesu, dodałem prostą komendę `(/review get-forum-tags-id)`, która w przypadku kanału przeznaczonego do prośb o review pobiera listę tagów i wyświetla ich identyfikatory oraz nazwy. Przykład takiego wyświetlenia można zobaczyć na zrzucie ekranu poniżej.

![image](https://github.com/EternalCodeTeam/DiscordOfficer/assets/65517973/86aed18e-fee8-40d7-841b-8b69983db530)

W kodzie wprowadziłem kilka zmian. Zmieniłem nazwę metody odpowiedzialnej za archiwizację zarchiwizowanych pull requestów na forum `deleteMergedPullRequests` **->** `archiveMergedPullRequest`. Ponadto, dodałem ustawienie w builderze `cdn-configs`, które umożliwia skanowanie również prywatnych pól. Bez tej opcji, pole `review.reviewers` w konfiguracji nie było poprawnie generowane.

**Całość została przetestowana i wdrożona na produkcje. 🚀**