### PR TITLE
GH-129 Send level-up on same channel and remove after 5 seconds.

### DIFF
--- a/src/main/java/com/eternalcode/discordapp/leveling/LevelConfig.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/LevelConfig.java
@@ -13,9 +13,6 @@ public class LevelConfig implements CdnConfig {
     @Description("# The count of points that will be added to the user's level")
     public int points = 100;
 
-    @Description("# Channel where the message will be sent")
-    public long channel = 0L;
-
     public Message message = new Message();
 
     @Contextual

--- a/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
@@ -6,9 +6,13 @@ import com.eternalcode.discordapp.observer.Observer;
 import io.sentry.Sentry;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.Channel;
+import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import panda.utilities.text.Formatter;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class LevelController implements Observer<ExperienceChangeEvent> {
@@ -78,15 +82,20 @@ public class LevelController implements Observer<ExperienceChangeEvent> {
 
 
             try {
-                TextChannel channel = this.jda.getTextChannelById(event.channelId());
-                channel.sendMessage(messageContent).queue(message -> {
-                    message.delete().queueAfter(5, TimeUnit.SECONDS);
-                });
-            } catch (Exception exception) {
+                Optional<MessageChannel> textChannelOptional = Optional.ofNullable(this.jda.getTextChannelById(event.channelId()));
+
+                MessageChannel channel = textChannelOptional.orElse(this.jda.getPrivateChannelById(event.channelId()));
+
+                if (channel == null) {
+                    return null;
+                }
+
+                channel.sendMessage(messageContent).queue(message -> message.delete().queueAfter(5, TimeUnit.SECONDS));
+            }
+            catch (Exception exception) {
                 Sentry.captureException(exception);
                 exception.printStackTrace();
             }
-
 
             return userLevel;
         });

--- a/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
@@ -78,9 +78,9 @@ public class LevelController implements Observer<ExperienceChangeEvent> {
 
 
             try {
-                long channelId = event.channelId();
+                LongSupplier channelId = event.channelId();
 
-                MessageChannel channel = this.getChannelById(() -> channelId);
+                MessageChannel channel = this.getChannelById(channelId);
 
                 if (channel == null) {
                     return null;

--- a/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
@@ -88,7 +88,9 @@ public class LevelController implements Observer<ExperienceChangeEvent> {
 
                 channel.sendMessage(messageContent).queue(message -> message.delete().queueAfter(5, TimeUnit.SECONDS));
             }
-            catch (Exception ignored) {}
+            catch (Exception ignored) {
+
+            }
 
             return userLevel;
         });

--- a/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
@@ -3,17 +3,13 @@ package com.eternalcode.discordapp.leveling;
 import com.eternalcode.discordapp.leveling.experience.Experience;
 import com.eternalcode.discordapp.leveling.experience.ExperienceChangeEvent;
 import com.eternalcode.discordapp.observer.Observer;
-import io.sentry.Sentry;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.entities.channel.Channel;
-import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import panda.utilities.text.Formatter;
 
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 
 public class LevelController implements Observer<ExperienceChangeEvent> {
 
@@ -84,7 +80,7 @@ public class LevelController implements Observer<ExperienceChangeEvent> {
             try {
                 long channelId = event.channelId();
 
-                MessageChannel channel = this.getChannelById(channelId);
+                MessageChannel channel = this.getChannelById(() -> channelId);
 
                 if (channel == null) {
                     return null;
@@ -92,18 +88,15 @@ public class LevelController implements Observer<ExperienceChangeEvent> {
 
                 channel.sendMessage(messageContent).queue(message -> message.delete().queueAfter(5, TimeUnit.SECONDS));
             }
-            catch (Exception exception) {
-                Sentry.captureException(exception);
-                exception.printStackTrace();
-            }
+            catch (Exception ignored) {}
 
             return userLevel;
         });
     }
 
-    private MessageChannel getChannelById(long channelId) {
-        MessageChannel channel = this.jda.getPrivateChannelById(channelId);
+    private MessageChannel getChannelById(LongSupplier channelId) {
+        MessageChannel channel = this.jda.getPrivateChannelById(channelId.getAsLong());
 
-        return channel != null ? channel : this.jda.getTextChannelById(channelId);
+        return channel != null ? channel : this.jda.getTextChannelById(channelId.getAsLong());
     }
 }

--- a/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
@@ -82,9 +82,10 @@ public class LevelController implements Observer<ExperienceChangeEvent> {
 
 
             try {
-                Optional<MessageChannel> textChannelOptional = Optional.ofNullable(this.jda.getTextChannelById(event.channelId()));
+                long channelId = event.channelId();
 
-                MessageChannel channel = textChannelOptional.orElse(this.jda.getPrivateChannelById(event.channelId()));
+                MessageChannel channel = this.isPrivateChannel(channelId) ? this.jda.getPrivateChannelById(channelId)
+                    : this.jda.getTextChannelById(channelId);
 
                 if (channel == null) {
                     return null;
@@ -99,5 +100,9 @@ public class LevelController implements Observer<ExperienceChangeEvent> {
 
             return userLevel;
         });
+    }
+
+    public boolean isPrivateChannel(long channelId) {
+        return this.jda.getPrivateChannelById(channelId) != null;
     }
 }

--- a/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/LevelController.java
@@ -84,8 +84,7 @@ public class LevelController implements Observer<ExperienceChangeEvent> {
             try {
                 long channelId = event.channelId();
 
-                MessageChannel channel = this.isPrivateChannel(channelId) ? this.jda.getPrivateChannelById(channelId)
-                    : this.jda.getTextChannelById(channelId);
+                MessageChannel channel = this.getChannelById(channelId);
 
                 if (channel == null) {
                     return null;
@@ -102,7 +101,9 @@ public class LevelController implements Observer<ExperienceChangeEvent> {
         });
     }
 
-    public boolean isPrivateChannel(long channelId) {
-        return this.jda.getPrivateChannelById(channelId) != null;
+    private MessageChannel getChannelById(long channelId) {
+        MessageChannel channel = this.jda.getPrivateChannelById(channelId);
+
+        return channel != null ? channel : this.jda.getTextChannelById(channelId);
     }
 }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/ExperienceChangeEvent.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/ExperienceChangeEvent.java
@@ -1,4 +1,6 @@
 package com.eternalcode.discordapp.leveling.experience;
 
-public record ExperienceChangeEvent(Experience experience, long channelId) {
+import java.util.function.LongSupplier;
+
+public record ExperienceChangeEvent(Experience experience, LongSupplier channelId) {
 }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/ExperienceChangeEvent.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/ExperienceChangeEvent.java
@@ -1,4 +1,4 @@
 package com.eternalcode.discordapp.leveling.experience;
 
-public record ExperienceChangeEvent(Experience experience) {
+public record ExperienceChangeEvent(Experience experience, long channelId) {
 }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/ExperienceService.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/ExperienceService.java
@@ -16,18 +16,18 @@ public class ExperienceService {
         this.observerRegistry = observerRegistry;
     }
 
-    public CompletableFuture<Experience> saveExperience(Experience experience) {
+    public CompletableFuture<Experience> saveExperience(Experience experience, long channelId) {
         return this.experienceRepository.saveExperience(experience).whenComplete((experience1, throwable) -> {
             if (throwable == null) {
-                this.observerRegistry.publish(new ExperienceChangeEvent(experience1));
+                this.observerRegistry.publish(new ExperienceChangeEvent(experience1, channelId));
             }
         });
     }
 
-    public CompletableFuture<Experience> modifyPoints(long id, double points, boolean add) {
-        return this.experienceRepository.modifyPoints(id, points, add).whenComplete((experience, throwable) -> {
+    public CompletableFuture<Experience> modifyPoints(long userId, double points, boolean add, long channelId) {
+        return this.experienceRepository.modifyPoints(userId, points, add).whenComplete((experience, throwable) -> {
             if (throwable == null) {
-                this.observerRegistry.publish(new ExperienceChangeEvent(experience));
+                this.observerRegistry.publish(new ExperienceChangeEvent(experience, channelId));
             }
         });
     }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/ExperienceService.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/ExperienceService.java
@@ -5,6 +5,7 @@ import com.eternalcode.discordapp.observer.ObserverRegistry;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.LongSupplier;
 
 public class ExperienceService {
 
@@ -16,7 +17,7 @@ public class ExperienceService {
         this.observerRegistry = observerRegistry;
     }
 
-    public CompletableFuture<Experience> saveExperience(Experience experience, long channelId) {
+    public CompletableFuture<Experience> saveExperience(Experience experience, LongSupplier channelId) {
         return this.experienceRepository.saveExperience(experience).whenComplete((experience1, throwable) -> {
             if (throwable == null) {
                 this.observerRegistry.publish(new ExperienceChangeEvent(experience1, channelId));
@@ -24,7 +25,7 @@ public class ExperienceService {
         });
     }
 
-    public CompletableFuture<Experience> modifyPoints(long userId, double points, boolean add, long channelId) {
+    public CompletableFuture<Experience> modifyPoints(long userId, double points, boolean add, LongSupplier channelId) {
         return this.experienceRepository.modifyPoints(userId, points, add).whenComplete((experience, throwable) -> {
             if (throwable == null) {
                 this.observerRegistry.publish(new ExperienceChangeEvent(experience, channelId));

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceMessageListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceMessageListener.java
@@ -5,6 +5,8 @@ import com.eternalcode.discordapp.leveling.experience.ExperienceService;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.function.LongSupplier;
+
 public class ExperienceMessageListener extends ListenerAdapter {
 
     private final ExperienceConfig experienceConfig;
@@ -35,7 +37,7 @@ public class ExperienceMessageListener extends ListenerAdapter {
         double points = (double) message.length / this.experienceConfig.messageExperience.howManyWords * basePoints;
         long userId = event.getAuthor().getIdLong();
 
-        long channelId = event.getChannel().getIdLong();
+        LongSupplier channelId = () -> event.getChannel().getIdLong();
         this.experienceService.modifyPoints(userId, points, true, channelId).whenComplete((experience, throwable) -> {
             if (throwable != null) {
                 throwable.printStackTrace();

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceMessageListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceMessageListener.java
@@ -35,7 +35,8 @@ public class ExperienceMessageListener extends ListenerAdapter {
         double points = (double) message.length / this.experienceConfig.messageExperience.howManyWords * basePoints;
         long userId = event.getAuthor().getIdLong();
 
-        this.experienceService.modifyPoints(userId, points, true, event.getChannel().getIdLong()).whenComplete((experience, throwable) -> {
+        long idLong = event.getChannel().getIdLong();
+        this.experienceService.modifyPoints(userId, points, true, idLong).whenComplete((experience, throwable) -> {
             if (throwable != null) {
                 throwable.printStackTrace();
             }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceMessageListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceMessageListener.java
@@ -35,8 +35,8 @@ public class ExperienceMessageListener extends ListenerAdapter {
         double points = (double) message.length / this.experienceConfig.messageExperience.howManyWords * basePoints;
         long userId = event.getAuthor().getIdLong();
 
-        long idLong = event.getChannel().getIdLong();
-        this.experienceService.modifyPoints(userId, points, true, idLong).whenComplete((experience, throwable) -> {
+        long channelId = event.getChannel().getIdLong();
+        this.experienceService.modifyPoints(userId, points, true, channelId).whenComplete((experience, throwable) -> {
             if (throwable != null) {
                 throwable.printStackTrace();
             }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceMessageListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceMessageListener.java
@@ -21,7 +21,6 @@ public class ExperienceMessageListener extends ListenerAdapter {
             return;
         }
 
-
         this.givePoints(event);
     }
 
@@ -36,7 +35,7 @@ public class ExperienceMessageListener extends ListenerAdapter {
         double points = (double) message.length / this.experienceConfig.messageExperience.howManyWords * basePoints;
         long userId = event.getAuthor().getIdLong();
 
-        this.experienceService.modifyPoints(userId, points, true).whenComplete((experience, throwable) -> {
+        this.experienceService.modifyPoints(userId, points, true, event.getChannel().getIdLong()).whenComplete((experience, throwable) -> {
             if (throwable != null) {
                 throwable.printStackTrace();
             }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
@@ -3,8 +3,6 @@ package com.eternalcode.discordapp.leveling.experience.listener;
 import com.eternalcode.discordapp.leveling.experience.ExperienceConfig;
 import com.eternalcode.discordapp.leveling.experience.ExperienceService;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionRemoveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -48,13 +46,14 @@ public class ExperienceReactionListener extends ListenerAdapter {
     }
 
     private void modifyPoints(User event, long userId, double points) {
-        event.openPrivateChannel().queue(channel -> this.experienceService.modifyPoints(userId, points, true, channel.getIdLong())
-            .whenComplete((experience, throwable) -> {
+        long channel = event.openPrivateChannel().complete().getIdLong();
 
-            if (throwable != null) {
-                throwable.printStackTrace();
-            }
-        }));
+        this.experienceService.modifyPoints(userId, points, true, channel)
+            .whenComplete((experience, throwable) -> {
+                if (throwable != null) {
+                    throwable.printStackTrace();
+                }
+            });
     }
 
 }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
@@ -7,6 +7,8 @@ import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionRemoveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.function.LongSupplier;
+
 public class ExperienceReactionListener extends ListenerAdapter {
 
     private final ExperienceConfig experienceConfig;
@@ -46,9 +48,9 @@ public class ExperienceReactionListener extends ListenerAdapter {
     }
 
     private void modifyPoints(User event, long userId, double points) {
-        long channel = event.openPrivateChannel().complete().getIdLong();
+        LongSupplier channel = () -> event.openPrivateChannel().complete().getIdLong();
 
-        this.experienceService.modifyPoints(userId, points, true, () -> channel)
+        this.experienceService.modifyPoints(userId, points, true, channel)
             .whenComplete((experience, throwable) -> {
                 if (throwable != null) {
                     throwable.printStackTrace();

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
@@ -24,11 +24,13 @@ public class ExperienceReactionListener extends ListenerAdapter {
         long userId = event.getUserIdLong();
         double points = this.experienceConfig.basePoints * this.experienceConfig.reactionExperience.multiplier;
 
-        if (event.getUser().isBot()) {
+        User user = event.getUser();
+
+        if (user.isBot()) {
             return;
         }
 
-        this.modifyPoints(event.getUser(), userId, points);
+        this.modifyPoints(user, userId, points);
     }
 
     @Override
@@ -36,11 +38,13 @@ public class ExperienceReactionListener extends ListenerAdapter {
         long userId = event.getUserIdLong();
         double points = this.experienceConfig.basePoints * this.experienceConfig.reactionExperience.multiplier;
 
-        if (event.getUser().isBot()) {
+        User user = event.getUser();
+
+        if (user.isBot()) {
             return;
         }
 
-        this.modifyPoints(event.getUser(), userId, points);
+        this.modifyPoints(user, userId, points);
     }
 
     private void modifyPoints(User event, long userId, double points) {

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
@@ -21,7 +21,7 @@ public class ExperienceReactionListener extends ListenerAdapter {
         long userId = event.getUserIdLong();
         double points = this.experienceConfig.basePoints * this.experienceConfig.reactionExperience.multiplier;
 
-        this.experienceService.modifyPoints(userId, points, true).whenComplete((experience, throwable) -> {
+        this.experienceService.modifyPoints(userId, points, true, event.getChannel().getIdLong()).whenComplete((experience, throwable) -> {
             if (throwable != null) {
                 throwable.printStackTrace();
             }
@@ -33,7 +33,7 @@ public class ExperienceReactionListener extends ListenerAdapter {
         long userId = event.getUserIdLong();
         double points = this.experienceConfig.basePoints * this.experienceConfig.reactionExperience.multiplier;
 
-        this.experienceService.modifyPoints(userId, points, true).whenComplete((experience, throwable) -> {
+        this.experienceService.modifyPoints(userId, points, true, event.getChannel().getIdLong()).whenComplete((experience, throwable) -> {
             if (throwable != null) {
                 throwable.printStackTrace();
             }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
@@ -48,7 +48,7 @@ public class ExperienceReactionListener extends ListenerAdapter {
     private void modifyPoints(User event, long userId, double points) {
         long channel = event.openPrivateChannel().complete().getIdLong();
 
-        this.experienceService.modifyPoints(userId, points, true, channel)
+        this.experienceService.modifyPoints(userId, points, true, () -> channel)
             .whenComplete((experience, throwable) -> {
                 if (throwable != null) {
                     throwable.printStackTrace();

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
@@ -2,6 +2,7 @@ package com.eternalcode.discordapp.leveling.experience.listener;
 
 import com.eternalcode.discordapp.leveling.experience.ExperienceConfig;
 import com.eternalcode.discordapp.leveling.experience.ExperienceService;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
@@ -27,13 +28,7 @@ public class ExperienceReactionListener extends ListenerAdapter {
             return;
         }
 
-        event.getUser().openPrivateChannel().queue(channel -> {
-            this.experienceService.modifyPoints(userId, points, true, channel.getIdLong()).whenComplete((experience, throwable) -> {
-                if (throwable != null) {
-                    throwable.printStackTrace();
-                }
-            });
-        });
+        this.modifyPoints(event.getUser(), userId, points);
     }
 
     @Override
@@ -45,13 +40,17 @@ public class ExperienceReactionListener extends ListenerAdapter {
             return;
         }
 
-        event.getUser().openPrivateChannel().queue(channel -> {
-            this.experienceService.modifyPoints(userId, points, true, channel.getIdLong()).whenComplete((experience, throwable) -> {
-                if (throwable != null) {
-                    throwable.printStackTrace();
-                }
-            });
-        });
+        this.modifyPoints(event.getUser(), userId, points);
+    }
+
+    private void modifyPoints(User event, long userId, double points) {
+        event.openPrivateChannel().queue(channel -> this.experienceService.modifyPoints(userId, points, true, channel.getIdLong())
+            .whenComplete((experience, throwable) -> {
+
+            if (throwable != null) {
+                throwable.printStackTrace();
+            }
+        }));
     }
 
 }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceReactionListener.java
@@ -2,6 +2,8 @@ package com.eternalcode.discordapp.leveling.experience.listener;
 
 import com.eternalcode.discordapp.leveling.experience.ExperienceConfig;
 import com.eternalcode.discordapp.leveling.experience.ExperienceService;
+import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.events.message.react.MessageReactionRemoveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -21,10 +23,16 @@ public class ExperienceReactionListener extends ListenerAdapter {
         long userId = event.getUserIdLong();
         double points = this.experienceConfig.basePoints * this.experienceConfig.reactionExperience.multiplier;
 
-        this.experienceService.modifyPoints(userId, points, true, event.getChannel().getIdLong()).whenComplete((experience, throwable) -> {
-            if (throwable != null) {
-                throwable.printStackTrace();
-            }
+        if (event.getUser().isBot()) {
+            return;
+        }
+
+        event.getUser().openPrivateChannel().queue(channel -> {
+            this.experienceService.modifyPoints(userId, points, true, channel.getIdLong()).whenComplete((experience, throwable) -> {
+                if (throwable != null) {
+                    throwable.printStackTrace();
+                }
+            });
         });
     }
 
@@ -33,10 +41,16 @@ public class ExperienceReactionListener extends ListenerAdapter {
         long userId = event.getUserIdLong();
         double points = this.experienceConfig.basePoints * this.experienceConfig.reactionExperience.multiplier;
 
-        this.experienceService.modifyPoints(userId, points, true, event.getChannel().getIdLong()).whenComplete((experience, throwable) -> {
-            if (throwable != null) {
-                throwable.printStackTrace();
-            }
+        if (event.getUser().isBot()) {
+            return;
+        }
+
+        event.getUser().openPrivateChannel().queue(channel -> {
+            this.experienceService.modifyPoints(userId, points, true, channel.getIdLong()).whenComplete((experience, throwable) -> {
+                if (throwable != null) {
+                    throwable.printStackTrace();
+                }
+            });
         });
     }
 

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceVoiceListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceVoiceListener.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.function.LongSupplier;
 
 public class ExperienceVoiceListener extends ListenerAdapter {
 
@@ -52,7 +53,7 @@ public class ExperienceVoiceListener extends ListenerAdapter {
         long userId = event.getMember().getIdLong();
         this.usersVoiceActivityData.usersOnVoiceChannel.remove(event.getMember().getIdLong());
 
-        long voiceLeftChannelId = event.getChannelLeft().getIdLong();
+        LongSupplier voiceLeftChannelId = () -> event.getChannelLeft().getIdLong();
         this.experienceService.modifyPoints(userId, this.calculatePoints(event), true, voiceLeftChannelId).whenComplete((experience, throwable) -> {
             if (throwable != null) {
                 throwable.printStackTrace();

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceVoiceListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceVoiceListener.java
@@ -52,8 +52,8 @@ public class ExperienceVoiceListener extends ListenerAdapter {
         long userId = event.getMember().getIdLong();
         this.usersVoiceActivityData.usersOnVoiceChannel.remove(event.getMember().getIdLong());
 
-        long idLong = event.getChannelLeft().getIdLong();
-        this.experienceService.modifyPoints(userId, this.calculatePoints(event), true, idLong).whenComplete((experience, throwable) -> {
+        long voiceLeftChannelId = event.getChannelLeft().getIdLong();
+        this.experienceService.modifyPoints(userId, this.calculatePoints(event), true, voiceLeftChannelId).whenComplete((experience, throwable) -> {
             if (throwable != null) {
                 throwable.printStackTrace();
             }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceVoiceListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceVoiceListener.java
@@ -51,7 +51,7 @@ public class ExperienceVoiceListener extends ListenerAdapter {
 
         long userId = event.getMember().getIdLong();
         this.usersVoiceActivityData.usersOnVoiceChannel.remove(event.getMember().getIdLong());
-        this.experienceService.modifyPoints(userId, this.calculatePoints(event), true).whenComplete((experience, throwable) -> {
+        this.experienceService.modifyPoints(userId, this.calculatePoints(event), true, event.getChannelJoined().getIdLong()).whenComplete((experience, throwable) -> {
             if (throwable != null) {
                 throwable.printStackTrace();
             }

--- a/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceVoiceListener.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/experience/listener/ExperienceVoiceListener.java
@@ -51,7 +51,9 @@ public class ExperienceVoiceListener extends ListenerAdapter {
 
         long userId = event.getMember().getIdLong();
         this.usersVoiceActivityData.usersOnVoiceChannel.remove(event.getMember().getIdLong());
-        this.experienceService.modifyPoints(userId, this.calculatePoints(event), true, event.getChannelJoined().getIdLong()).whenComplete((experience, throwable) -> {
+
+        long idLong = event.getChannelLeft().getIdLong();
+        this.experienceService.modifyPoints(userId, this.calculatePoints(event), true, idLong).whenComplete((experience, throwable) -> {
             if (throwable != null) {
                 throwable.printStackTrace();
             }

--- a/src/main/java/com/eternalcode/discordapp/leveling/games/CodeGameAnswerController.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/games/CodeGameAnswerController.java
@@ -11,6 +11,7 @@ import java.awt.Color;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Random;
+import java.util.function.LongSupplier;
 
 public class CodeGameAnswerController extends ListenerAdapter {
 
@@ -34,9 +35,9 @@ public class CodeGameAnswerController extends ListenerAdapter {
             return;
         }
 
-        long channelId = event.getChannel().getIdLong();
+        LongSupplier channelId = () -> event.getChannel().getIdLong();
 
-        if (channelId != this.codeGameConfiguration.channelId) {
+        if (channelId.getAsLong() != this.codeGameConfiguration.channelId) {
             return;
         }
 
@@ -67,6 +68,7 @@ public class CodeGameAnswerController extends ListenerAdapter {
                 .setColor(Color.decode(this.codeGameConfiguration.embedSettings.color))
                 .setDescription(formatter.format(this.codeGameConfiguration.embedSettings.description))
                 .setFooter(this.codeGameConfiguration.embedSettings.footer);
+
 
             this.experienceService.modifyPoints(event.getAuthor().getIdLong(), points, true, channelId)
                 .whenComplete((experience, throwable) -> {

--- a/src/main/java/com/eternalcode/discordapp/leveling/games/CodeGameAnswerController.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/games/CodeGameAnswerController.java
@@ -66,7 +66,7 @@ public class CodeGameAnswerController extends ListenerAdapter {
                 .setDescription(formatter.format(this.codeGameConfiguration.embedSettings.description))
                 .setFooter(this.codeGameConfiguration.embedSettings.footer);
 
-            this.experienceService.modifyPoints(event.getAuthor().getIdLong(), points, true)
+            this.experienceService.modifyPoints(event.getAuthor().getIdLong(), points, true, event.getChannel().getIdLong())
                 .whenComplete((experience, throwable) -> {
                     if (throwable != null) {
                         throwable.printStackTrace();

--- a/src/main/java/com/eternalcode/discordapp/leveling/games/CodeGameAnswerController.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/games/CodeGameAnswerController.java
@@ -34,7 +34,9 @@ public class CodeGameAnswerController extends ListenerAdapter {
             return;
         }
 
-        if (event.getChannel().getIdLong() != this.codeGameConfiguration.channelId) {
+        long idLong = event.getChannel().getIdLong();
+
+        if (idLong != this.codeGameConfiguration.channelId) {
             return;
         }
 
@@ -66,7 +68,7 @@ public class CodeGameAnswerController extends ListenerAdapter {
                 .setDescription(formatter.format(this.codeGameConfiguration.embedSettings.description))
                 .setFooter(this.codeGameConfiguration.embedSettings.footer);
 
-            this.experienceService.modifyPoints(event.getAuthor().getIdLong(), points, true, event.getChannel().getIdLong())
+            this.experienceService.modifyPoints(event.getAuthor().getIdLong(), points, true, idLong)
                 .whenComplete((experience, throwable) -> {
                     if (throwable != null) {
                         throwable.printStackTrace();

--- a/src/main/java/com/eternalcode/discordapp/leveling/games/CodeGameAnswerController.java
+++ b/src/main/java/com/eternalcode/discordapp/leveling/games/CodeGameAnswerController.java
@@ -34,9 +34,9 @@ public class CodeGameAnswerController extends ListenerAdapter {
             return;
         }
 
-        long idLong = event.getChannel().getIdLong();
+        long channelId = event.getChannel().getIdLong();
 
-        if (idLong != this.codeGameConfiguration.channelId) {
+        if (channelId != this.codeGameConfiguration.channelId) {
             return;
         }
 
@@ -68,7 +68,7 @@ public class CodeGameAnswerController extends ListenerAdapter {
                 .setDescription(formatter.format(this.codeGameConfiguration.embedSettings.description))
                 .setFooter(this.codeGameConfiguration.embedSettings.footer);
 
-            this.experienceService.modifyPoints(event.getAuthor().getIdLong(), points, true, idLong)
+            this.experienceService.modifyPoints(event.getAuthor().getIdLong(), points, true, channelId)
                 .whenComplete((experience, throwable) -> {
                     if (throwable != null) {
                         throwable.printStackTrace();


### PR DESCRIPTION
Fixes GH-129

# Why?
Because to recude spam at the channels.

# Working

https://github.com/EternalCodeTeam/DiscordOfficer/assets/65517973/5f16985d-16ae-4fb8-8876-99ec22d5f99c

# READ-ME

Sure, you might wonder why the level-up message from a reaction is sent via DM. This is because, let's assume that a user received a level-up notification in the announcements channel; in that case, the level-up message would be sent on that channel, which is something we'd prefer to avoid. That's why I send the level-up message from the reaction via DM.
